### PR TITLE
Devel

### DIFF
--- a/tlp.service
+++ b/tlp.service
@@ -19,4 +19,4 @@ ExecStart=/usr/sbin/tlp init start
 ExecStop=/usr/sbin/tlp init stop
 
 [Install]
-WantedBy=graphical.target
+WantedBy=local-fs.target


### PR DESCRIPTION
The systemd unit requires graphical target unnecessarily, so TLP will not start when logging in with console-only.
