### PR TITLE
tlp.service: Set type to simple

### DIFF
--- a/tlp.service
+++ b/tlp.service
@@ -9,7 +9,7 @@ After=multi-user.target
 Before=shutdown.target
 
 [Service]
-Type=oneshot
+Type=simple
 RemainAfterExit=yes
 ExecStart=/usr/sbin/tlp init start
 ExecStop=/usr/sbin/tlp init stop


### PR DESCRIPTION
no one service depend on tlp service while boot
according to http://freedesktop.org/wiki/Software/systemd/Optimizations/
Quote:
23. The usual housekeeping: get rid of shell-based services (i.e. SysV init scripts), replace them with unit files. Don't make use of Type=forking and ordering dependencies if possible, use socket activation with Type=simple instead. This allows drastically better parallelized start-up for your services. Also, if you cannot use socket activation, at least consider patching your services to support Type=notify in place of Type=forking. Consider making seldom used services activated on-demand (for example, printer services), and start frequently used services already at boot instead of delaying them until they are used.

simple tipe, allow systemd not stop boot, while service a boot and do start of service in backgroud.
