### PR TITLE
remove pm-utils dependency in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://linrunner.de/tlp
 
 Package: tlp
 Architecture: all
-Depends: ${misc:Depends}, pm-utils
+Depends: ${misc:Depends}
 Recommends: tlp-rdw, acpid, ethtool, smartmontools, wireless-tools
 Suggests: acpi-call, tp-smapi-dkms
 Conflicts: pm-utils-powersave-policy


### PR DESCRIPTION
TLP does not use pm-utils since 0.4.1 but the debian control still lists pm-utils as a dependency. 
