### PR TITLE
Support dock/undock detection for the OneLink dock

### DIFF
--- a/tlp-rdw.rules
+++ b/tlp-rdw.rules
@@ -19,3 +19,6 @@ ACTION=="add|remove", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}
 
 # ThinkPad Basic Dock
 # *** TODO: yet unknown ***
+
+# ThinkPad OneLink Dock
+ACTION=="add|remove", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}=="17ef/304b/*", RUN+="/lib/udev/tlp-rdw-udev %p usb_dock"


### PR DESCRIPTION
It uses the ethernet chip in the dock to detect dock/undock events.