### PR TITLE
tlp-rdw-nm can't detect interface type of disconnected network card

### DIFF
--- a/tlp-rdw-nm.in
+++ b/tlp-rdw-nm.in
@@ -57,7 +57,22 @@ if cmd_exists $NMCLI ; then
         if wordinlist "$iface" "$wanifaces"; then
             itype="wwan"
         else
-            itype="unknown"
+            # if interface type detetion with nmcli failed, then try to
+            # deduct it using interface name: it can happen if e.g.
+            # usb network card is unplugged
+            case "$iface" in
+                en* | eth*)
+                    itype="ethernet"
+                    ;;
+
+                wl* | wlan*)
+                    itype="wifi"
+                    ;;
+
+                *)
+                    itype="unknown"
+                    ;;
+            esac
         fi
     fi
     echo_debug "nm" "rdw_nm($iface).$action: type=$itype [nmcli]"


### PR DESCRIPTION
Hi,

I'm using the USB ethernet network card and this is the only wired network interface that I have. I want to make use of the radio control provided by TLP. I've set it up to disabled wifi on LAN connect and to enable wifi on LAN disconnect.

The problem I experience is that when I unplug the USB network card tlp-rdw-nm can't detect its interface type because nmcli doesn't list this interface any longer and thus tlp-rdw-nm doesn't proceed to enable wifi.

To remedy this problem I added the additional code to tlp-rdw-nm to check the interface name if type detection with nmcli failed. It's similar to wwan detection already in place.