### PR TITLE
Make always enabling the Wi-fi radio on shutdown configurable

### DIFF
--- a/changelog
+++ b/changelog
@@ -6,6 +6,10 @@
     Radio Devices:
       - Finally remove deprecated DEVICES_TO_ENABLE_ON_RADIOSW code
         (works with Ubuntu 12.04/Kernel 3.2 only)
+      - Add the ALWAYS_ENABLE_WIFI_ON_SHUTDOWN option, that defaults to enabled.
+        It reflects behavior from previous versions, that works around some
+        issues with NetworkManager not starting up Wi-fi after a reboot, but now
+        can be disabled if desired.
     (ThinkPad) Battery:
       - tlp-stat:
         - Distinguish tp-smapi incompatible hardware from load errors (Issue #160)

--- a/default
+++ b/default
@@ -196,6 +196,10 @@ USB_BLACKLIST_WWAN=1
 #   are ignored when this is enabled!
 RESTORE_DEVICE_STATE_ON_STARTUP=0
 
+# Always enable the Wi-fi radio on shutdown. Works around some issues
+# with NetworkManager, so disable with care.
+ALWAYS_ENABLE_WIFI_ON_SHUTDOWN=1
+
 # Radio devices to disable on startup: bluetooth, wifi, wwan.
 # Separate multiple devices with spaces.
 #DEVICES_TO_DISABLE_ON_STARTUP="bluetooth wifi wwan"

--- a/tlp-rf-func
+++ b/tlp-rf-func
@@ -347,8 +347,10 @@ set_radio_device_states () { # set/initialize all radio states
 
                 # NM workaround: when not explicitly configured,
                 # re-enable wifi on shutdown to prepare for startup
-                if ! wordinlist "wifi" "$devs2disable $devs2enable"; then
-                    devs2enable="wifi $devs2enable"
+                if [ "$ALWAYS_ENABLE_WIFI_ON_SHUTDOWN" = 1 ]; then
+                    if ! wordinlist "wifi" "$devs2disable $devs2enable"; then
+                        devs2enable="wifi $devs2enable"
+                    fi
                 fi
                 ;;
 


### PR DESCRIPTION
It was previously always enabled, even if the list of devices to change
on shutdown/startup was empty, as a workaround for NetworkManager
issues. Make it optional.