### PR TITLE
Fix rdw_nm script to wait in case of timed lock

### DIFF
--- a/tlp-rdw-nm.in
+++ b/tlp-rdw-nm.in
@@ -11,6 +11,7 @@ readonly LIBS="tlp-functions tlp-rf-func"
 
 readonly RDW_NM_LOCK="rdw_nm"
 readonly RDW_NM_LOCKTIME=2
+readonly RDW_NM_LOCKTRIES=3
 
 # --- Source libraries
 for lib in $LIBS; do
@@ -42,7 +43,12 @@ else
 fi
 
 # Quit if timed lock in progress
-check_timed_lock $RDW_NM_LOCK && exit 0
+_i=0
+while check_timed_lock $RDW_NM_LOCK ; do
+    [ "$_i" -eq "$RDW_NM_LOCKTRIES" ] && exit 0
+    sleep $RDW_NM_LOCKTIME
+    _i=`expr $_i + 1`
+done
 
 # Determine interface type
 if cmd_exists $NMCLI ; then


### PR DESCRIPTION
If NetworkManager run the dispatcher scripts too fast, the rdw_nm won't
be able to turn off the required devices, e.g., NetworkManager turns on
the WiFi fist and then, the Ethernet link. Normally the user will configure TLP
so it turns off the Wifi, if the Ethernet link is on. The first execution
of rdw_nm won't do anything but sets up a timed lock. The second
execution should turn off the WiFi, but since there's a valid timed lock, it
exits immediately leaving the network devices in the wrong state.

With this patch, rdw_nm will wait at least three times in case there's a
valid timed lock.