### PR TITLE
Add the ability to blacklist SATA host devices, if necessary.

### DIFF
--- a/default
+++ b/default
@@ -107,6 +107,10 @@ DISK_APM_LEVEL_ON_BAT="128 128"
 SATA_LINKPWR_ON_AC=max_performance
 SATA_LINKPWR_ON_BAT=min_power
 
+# Exclude SATA host devices from power management.
+# Separate multiple hosts with spaces.
+#SATA_LINKPWR_BLACKLIST="host1"
+
 # PCI Express Active State Power Management (PCIe ASPM):
 #   default, performance, powersave
 PCIE_ASPM_ON_AC=performance

--- a/tlp-functions.in
+++ b/tlp-functions.in
@@ -1089,7 +1089,7 @@ set_disk_io_sched () { # set disk io scheduler
 set_sata_link_power () { # set sata link power management
     # $1: 0=ac mode, 1=battery mode
 
-    local i
+    local i link_bl hostid
     local pwr=""
     local ctrl_avail="0"
 
@@ -1107,10 +1107,16 @@ set_sata_link_power () { # set sata link power management
 
     echo_debug "pm" "set_sata_link_power($1): $pwr"
 
+    # ALPM blacklist
+    link_bl=${SATA_LINKPWR_BLACKLIST:-}
+
     for i in /sys/class/scsi_host/host*/link_power_management_policy ; do
+        hostid=$(basename $(dirname "$i"))
         if [ -f $i ]; then
-            printf '%s\n' "$pwr" > $i
-            ctrl_avail="1"
+            if ! wordinlist "$hostid" "$link_bl"; then
+                printf '%s\n' "$pwr" > $i
+                ctrl_avail="1"
+            fi
         fi
     done
 


### PR DESCRIPTION
On my system (a Dell Precision M3800), when switching to battery my screen would start flickering every few seconds. Thinking this might be due to Optimus, I tried to blacklist the `nvidia` driver as mentioned in the FAQ, but that did not fix the problem. Using `powertop` I was actually able to track the problem down to one certain SATA host (`/sys/class/scsi_host/host1`, for what that's worth). The other SATA links could be set to `min_power` with no issue, but `host1` would cause the screen to flicker if it was set to anything other than the default, `max_performance`. I saw that TLP didn't have a way to blacklist devices from ALPM changes, so that's what this patch adds. This way the other links can be set to `min_power` or whatever, leaving misbehaving links alone.