### PR TITLE
tlp-stat: i915 modeset status

### DIFF
--- a/tlp-stat.in
+++ b/tlp-stat.in
@@ -811,6 +811,7 @@ if [ "$show_all" = "1" ]; then
         printparm_i915 $I915D/enable_fbc $I915D/i915_enable_fbc
         printparm_i915 $I915D/enable_psr
         printparm_i915 $I915D/lvds_downclock
+        printparm_i915 $I915D/modeset
         printparm_i915 $I915D/semaphores
         echo
     fi


### PR DESCRIPTION
If `i915.modeset=1` is set, then driver is loaded in KMS mode. 
tlp-stat tool can easy check this.
@linrunner 

Tested localy, all is fine.

![screenshot_20160523_142213](https://cloud.githubusercontent.com/assets/9846948/15470592/c30fd3be-20f1-11e6-899d-d4c0ae0d7463.png)
