### PR TITLE
tlp: Add TLP_PERSISTENT_DEFAULT to make TLP_DEFAULT_MODE persistent.

### DIFF
--- a/default
+++ b/default
@@ -12,6 +12,9 @@ TLP_ENABLE=1
 # Concerns some desktop and embedded hardware only.
 TLP_DEFAULT_MODE=AC
 
+# Always use TLP_DEFAULT_MODE regardless the power supply status.
+TLP_PERSISTENT_DEFAULT=0
+
 # Seconds laptop mode has to wait after the disk goes idle before doing a sync.
 # Non-zero value enables, zero disables laptop mode.
 DISK_IDLE_SECS_ON_AC=0

--- a/tlp-functions.in
+++ b/tlp-functions.in
@@ -355,6 +355,15 @@ get_power_state () { # get current power source -- rc: 0=ac, 1=battery
     # but maps unknown power source to TLP_DEFAULT_MODE
     local psrc
 
+    if [ "$TLP_PERSISTENT_DEFAULT" = "1" ]; then
+        case "$TLP_DEFAULT_MODE" in
+            bat|BAT) psrc=1 ;;
+            *)       psrc=0 ;;
+        esac
+
+        return $psrc
+    fi
+
     get_sys_power_supply
     psrc=$?
 


### PR DESCRIPTION
I'd like to make my laptop use BAT mode all the time, especially when the battery is charging, to keep my lap away from fried :)

So I added another option to make the default mode persistent. I guess others may find this useful too.
