### PR TITLE
Add option to ignore specific devices in tlp-rdw

### DIFF
--- a/changelog
+++ b/changelog
@@ -6,6 +6,9 @@
     Graphics:
       - Add "amdgpu" to RUNTIME_PM_DRIVER_BLACKLIST; driver default "auto"
         allows to turn the card off
+    Radio Devices:
+      - Add DEVICES_TO_IGNORE_AS_NETWORK option to give specific devices which
+        shall not trigger the radio device wizard
     ThinkPad Battery:
       - RESTORE_THRESHOLDS_ON_BAT: restore charge thresholds on battery
       - Detect Thinkpad 13 as unsupported (Issue #227)

--- a/default
+++ b/default
@@ -279,3 +279,7 @@ RESTORE_DEVICE_STATE_ON_STARTUP=0
 # Radio devices to enable/disable when undocked.
 #DEVICES_TO_ENABLE_ON_UNDOCK="wifi"
 #DEVICES_TO_DISABLE_ON_UNDOCK=""
+
+# Devices which shall not trigger the radio device wizard
+# Enter exact device names here
+#DEVICES_TO_IGNORE_AS_NETWORK=""

--- a/tlp-rdw-nm.in
+++ b/tlp-rdw-nm.in
@@ -54,6 +54,9 @@ itype="unknown"
 # Quit for invalid interfaces
 [ -n "$iface" ] && [ "$iface" != "none" ] || exit 0
 
+# Quit for ignored interfaces
+wordinlist "$iface" "${DEVICES_TO_IGNORE_AS_NETWORK}" && exit 0
+
 # Quit for actions other than "up" and "down"
 [ "$action" = "up" ] || [ "$action" = "down" ] || exit 0
 


### PR DESCRIPTION
This adds the option DEVICES_TO_IGNORE_AS_NETWORK, which takes a list of devices names. If any of these devices is (de-)activated, no action is taken, if the type of the device would otherwise enable or disable other devices.

I use it to ignore the device 'vboxnet0', which is considered as type LAN. However, I do only want actual LAN devices to change the state of my WIFI, therefore I choose to ignore the vboxnet0 device.