### PR TITLE
add support for OneLink Dock Plus

### DIFF
--- a/tlp-rdw.rules.in
+++ b/tlp-rdw.rules.in
@@ -26,3 +26,6 @@ ACTION=="add|remove", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}
 
 # ThinkPad OneLink Dock
 ACTION=="add|remove", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}=="17ef/3049/*", RUN+="@TLP_ULIB@/tlp-rdw-udev %p usb_dock"
+
+# ThinkPad OneLink Dock Plus
+ACTION=="add|remove", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}=="17ef/3054/*", RUN+="@TLP_ULIB@/tlp-rdw-udev %p usb_dock"


### PR DESCRIPTION
output of `lsusb` on my docked system:

```$ lsusb 
Bus 002 Device 007: ID 17ef:3054 Lenovo 
Bus 002 Device 006: ID 17ef:1019 Lenovo 
Bus 002 Device 005: ID 17ef:1018 Lenovo 
Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
Bus 001 Device 005: ID 138a:0090 Validity Sensors, Inc. 
Bus 001 Device 004: ID 04f2:b531 Chicony Electronics Co., Ltd 
Bus 001 Device 008: ID 8087:0a2b Intel Corp. 
Bus 001 Device 020: ID 046d:c52b Logitech, Inc. Unifying Receiver
Bus 001 Device 017: ID 05e3:0608 Genesys Logic, Inc. Hub
Bus 001 Device 021: ID 17ef:3055 Lenovo 
Bus 001 Device 019: ID 17ef:1019 Lenovo 
Bus 001 Device 016: ID 17ef:1018 Lenovo 
Bus 001 Device 009: ID 1199:9079 Sierra Wireless, Inc. 
Bus 001 Device 006: ID 056a:503f Wacom Co., Ltd 
Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub```