### PR TITLE
default: change SOUND_POWER_SAVE_ON_BAT to 10

### DIFF
--- a/default
+++ b/default
@@ -170,7 +170,7 @@ WOL_DISABLE=Y
 # Enable audio power saving for Intel HDA, AC97 devices (timeout in secs).
 # A value of 0 disables, >=1 enables power saving.
 SOUND_POWER_SAVE_ON_AC=0
-SOUND_POWER_SAVE_ON_BAT=1
+SOUND_POWER_SAVE_ON_BAT=10
 
 # Disable controller too (HDA only): Y/N
 SOUND_POWER_SAVE_CONTROLLER=Y


### PR DESCRIPTION
Excerpt from kernel documentation [1]:

Setting this to 1 (the minimum value) isn’t recommended because many
applications try to reopen the device frequently. 10 would be a good
choice for normal operations.

[1] https://www.kernel.org/doc/html/latest/sound/designs/powersave.html