### PR TITLE
Add AppStream metadata

### DIFF
--- a/de.linrunner.tlp.metainfo.xml
+++ b/de.linrunner.tlp.metainfo.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<component>
+
+  <id>de.linrunner.tlp</id>
+  <metadata_license>MIT</metadata_license>
+  <name>TLP</name>
+
+  <summary>Save battery power on laptops</summary>
+  <description>
+    <p>
+      TLP is an advanced power management tool for Linux. It comes with a
+      default configuration already optimized for battery life. At the same
+      time it is highly customizable to fulfil specific user requirements.
+    </p>
+    <p>
+      TLP supplies separate settings profiles for AC and battery power and can
+      enable or disable bluetooth, WiFi and WWAN radio devices upon system
+      startup.
+    </p>
+    <p>
+      For ThinkPads it provides a unified way to configure charging thresholds
+      and recalibrate the battery for all models which support it (via tp-smapi
+      or acpi-call).
+    </p>
+    <p>
+      TLP is a pure command line tool with automated background tasks, it does
+      not contain a GUI.
+    </p>
+  </description>
+
+  <categories>
+    <category>System</category>
+  </categories>
+
+  <!-- Do we want software centers to automatically launch TLP ? -->
+  <!-- <launchable type="service">tlp</launchable> -->
+
+  <project_license>GPL-2.0+</project_license>
+  <developer_name>Thomas Koch</developer_name>
+  <url type="homepage">http://linrunner.de/tlp</url>
+
+  <provides>
+    <!-- Match "Portable" chassis type -->
+    <modalias>dmi:*:ct8:*</modalias>
+    <!-- Match "Laptop" chassis type -->
+    <modalias>dmi:*:ct9:*</modalias>
+    <!-- Match "Notebook" chassis type -->
+    <modalias>dmi:*:ct10:*</modalias>
+    <!-- Match "battery" kernel module -->
+    <modalias>acpi:PNP0C0A:*</modalias>
+  </provides>
+
+</component>


### PR DESCRIPTION
Hi,

According to the [AppStream guidelines](https://wiki.debian.org/AppStream/Guidelines) from Debian:

> Each AppStream component has a unique identifier (the value of the <id/> tag), which is unique across all distributions. So if you add new metadata which does not originate from upstream, make sure that you contribute the changes back to your upstream project to make the ID really unique.

So, I'd like to contribute this file I added to the latest Debian package, so it can be included upstream for use by package maintainers of other distributions.

Notes:

- The `<id>` section is built from the project's homepage URL, to make it unique
- The `<summary>` and `<description>` texts are taken directly from the Debian package
- The `<provides>` section basically does what the `laptop-detect` Debian packages does, that is, checking for the chassis type, and if a battery is used

For more information, please read the [official AppStream documentation](https://www.freedesktop.org/software/appstream/docs/index.html).