### PR TITLE
Add test for presence of /var/run

### DIFF
--- a/tlp.rules.in
+++ b/tlp.rules.in
@@ -4,7 +4,7 @@
 # This software is licensed under the GPL v2 or later.
 
 # handle change of power source ac/bat
-ACTION=="change", SUBSYSTEM=="power_supply", RUN+="@TLP_SBIN@/tlp auto"
+ACTION=="change", SUBSYSTEM=="power_supply", TEST=="/var/run", RUN+="@TLP_SBIN@/tlp auto"
 
 # handle added usb devices (exclude subdevices via DRIVER=="USB")
 ACTION=="add", SUBSYSTEM=="usb", DRIVER=="usb", ENV{DEVTYPE}=="usb_device", RUN+="@TLP_ULIB@/tlp-usb-udev %p"


### PR DESCRIPTION
If /var is mounted from a different partition, the /var/run directory may not be present immediately. In that case, /var/run/tlp should not be created, but rather we should wait until it is present.

Otherwise, the /var mountpoint in the / filesystem will not be empty (which is wrong) and anything below that won't be reachable anyway once /var (and /var/run) is mounted. Adding a test for the presence of /var/run will prevent this from happening.