### PR TITLE
tlp-stat.in: RFKILL_SERVICES add SOCKET

### DIFF
--- a/tlp-stat.in
+++ b/tlp-stat.in
@@ -32,7 +32,7 @@ readonly JOURNALCTL=journalctl
 readonly DEBUGLOG=/var/log/debug
 
 readonly SYSTEMD_SERVICES="tlp.service tlp-sleep.service"
-readonly RFKILL_SERVICES="systemd-rfkill.service"
+readonly RFKILL_SERVICES="systemd-rfkill.service systemd-rfkill.socket"
 
 readonly EFID=/sys/firmware/efi
 


### PR DESCRIPTION
Masking only `systemd-rfkill.service` DID NOT shutdown RFKILL service (and made systemd error during boot against SOCKET trying running). Correct masking service and socket resolve issue.

```
sudo systemctl mask systemd-rfkill.socket systemd-rfkill.service
```

Patch work when tlp find unmasked services:
![screenshot_20180224_185637](https://user-images.githubusercontent.com/9846948/36633363-7d1cc54a-1994-11e8-93fc-d5bb6bfdeca7.png)
