### PR TITLE
Fix tlp stat for enable_dc

### DIFF
--- a/tlp-stat.in
+++ b/tlp-stat.in
@@ -141,9 +141,9 @@ printparm_i915 () { # formatted output of sysfile - i915 kernel module variant
                 else
                     # other parms
                     if [ $(( $val & 1 )) -ne 0 ]; then
-                        echo -n "enabled"
-                    else
                         echo -n "disabled"
+                    else
+                        echo -n "enabled"
                     fi
                     [ $(( $val & 2 )) -ne 0 ] && echo -n " + deep"
                     [ $(( $val & 4 )) -ne 0 ] && echo -n " + deepest"


### PR DESCRIPTION
```
>sudo modinfo -p i915
enable_dc:Enable power-saving display C-states. (-1=auto [default]; 0=disable; 1=up to DC5; 2=up to DC6) (int)
```
This may be incorrect for those who have enable_rc6 but I cannot test this.