### PR TITLE
Add TimeoutStopSec to systemd service

### DIFF
--- a/tlp.service.in
+++ b/tlp.service.in
@@ -15,6 +15,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=@TLP_SBIN@/tlp init start
 ExecStop=@TLP_SBIN@/tlp init stop
+TimeoutStopSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Sometimes tlp will inhibit shutdown; 5 seconds is ample time to finish normal operations, after that it is most likely a hardware snafu that hangs indefinitely.