### PR TITLE
USB_AUTOSUSPEND is enabled by default

### DIFF
--- a/default
+++ b/default
@@ -268,7 +268,7 @@ RUNTIME_PM_ON_BAT=auto
 #RUNTIME_PM_DRIVER_BLACKLIST="amdgpu mei_me nouveau nvidia pcieport radeon"
 
 # Set to 0 to disable, 1 to enable USB autosuspend feature.
-# Default: 0
+# Default: 1
 USB_AUTOSUSPEND=1
 
 # Exclude listed devices from USB autosuspend (separate with spaces).


### PR DESCRIPTION
USB_AUTOSUSPEND is enabled by default it seems.
If this is incorrect (both value as the branch) please let me know.