### PR TITLE
Customize folder runconf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ TLP_TLIB   ?= /usr/share/tlp
 TLP_FLIB   ?= /usr/share/tlp/func.d
 TLP_ULIB   ?= /lib/udev
 TLP_NMDSP  ?= /etc/NetworkManager/dispatcher.d
-TLP_CONF   ?= /etc/default/tlp
+TLP_CONFDEF   ?= /usr/share/tlp/defaults.conf
+TLP_CONFTEMP   ?= /etc/tlp.conf
+TLP_CONFOUTDATED   ?= /etc/default/tlp
 TLP_SYSD   ?= /lib/systemd/system
 TLP_SDSL   ?= /lib/systemd/system-sleep
 TLP_SYSV   ?= /etc/init.d
@@ -18,7 +20,7 @@ TLP_META   ?= /usr/share/metainfo
 TLP_RUN    ?= /run/tlp
 TLP_RUNCONF    ?= /run/tlp/tlp.conf
 TLP_VAR    ?= /var/lib/tlp
-TLP_CUSTOMIZE    ?= /etc/tlp.conf.d
+TLP_CONFD  ?= /etc/tlp.conf.d
 
 # Catenate DESTDIR to paths
 _SBIN  = $(DESTDIR)$(TLP_SBIN)
@@ -27,7 +29,9 @@ _TLIB  = $(DESTDIR)$(TLP_TLIB)
 _FLIB  = $(DESTDIR)$(TLP_FLIB)
 _ULIB  = $(DESTDIR)$(TLP_ULIB)
 _NMDSP = $(DESTDIR)$(TLP_NMDSP)
-_CONF  = $(DESTDIR)$(TLP_CONF)
+_CONFDEF  = $(DESTDIR)$(TLP_CONFDEF)
+_CONFTEMP  = $(DESTDIR)$(TLP_CONFTEMP)
+_CONFD  = $(DESTDIR)$(TLP_CONFD)
 _SYSD  = $(DESTDIR)$(TLP_SYSD)
 _SDSL  = $(DESTDIR)$(TLP_SDSL)
 _SYSV  = $(DESTDIR)$(TLP_SYSV)
@@ -43,8 +47,10 @@ SED = sed \
 	-e "s|@TLP_TLIB@|$(TLP_TLIB)|g" \
 	-e "s|@TLP_FLIB@|$(TLP_FLIB)|g" \
 	-e "s|@TLP_ULIB@|$(TLP_ULIB)|g" \
-	-e "s|@TLP_CONF@|$(TLP_CONF)|g" \
-	-e "s|@TLP_CUSTOMIZE@|$(TLP_CUSTOMIZE)|g" \
+	-e "s|@TLP_CONFDEF@|$(TLP_CONFDEF)|g" \
+	-e "s|@TLP_CONFTEMP@|$(TLP_CONFTEMP)|g" \
+	-e "s|@TLP_CONFOUTDATED@|$(TLP_CONFOUTDATED)|g" \
+	-e "s|@TLP_CONFD@|$(TLP_CONFD)|g" \
 	-e "s|@TLP_RUN@|$(TLP_RUN)|g"   \
 	-e "s|@TLP_RUNCONF@|$(TLP_RUNCONF)|g"   \
 	-e "s|@TLP_VAR@|$(TLP_VAR)|g"
@@ -122,7 +128,9 @@ endif
 	install -D -m 755 --target-directory $(_TLIB)/func.d func.d/*
 	install -D -m 755 tlp-usb-udev $(_ULIB)/tlp-usb-udev
 	install -D -m 644 tlp.rules $(_ULIB)/rules.d/85-tlp.rules
-	[ -f $(_CONF) ] || install -D -m 644 default $(_CONF)
+	[ -f $(_CONFDEF) ] || install -D -m 644 default $(_CONFDEF)
+	[ -f $(_CONFTEMP) ] || install -D -m 644 template $(_CONFTEMP)
+	[ -f $(_CONFD)/00_template ] || install -D -m 644 template $(_CONFD)/00_template
 ifneq ($(TLP_NO_INIT),1)
 	install -D -m 755 tlp.init $(_SYSV)/tlp
 endif

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ TLP_SHCPL  ?= /usr/share/bash-completion/completions
 TLP_MAN    ?= /usr/share/man
 TLP_META   ?= /usr/share/metainfo
 TLP_RUN    ?= /run/tlp
+TLP_RUNCONF    ?= /run/tlp/tlp.conf
 TLP_VAR    ?= /var/lib/tlp
 TLP_CUSTOMIZE    ?= /etc/tlp.conf.d
 
@@ -45,6 +46,7 @@ SED = sed \
 	-e "s|@TLP_CONF@|$(TLP_CONF)|g" \
 	-e "s|@TLP_CUSTOMIZE@|$(TLP_CUSTOMIZE)|g" \
 	-e "s|@TLP_RUN@|$(TLP_RUN)|g"   \
+	-e "s|@TLP_RUNCONF@|$(TLP_RUNCONF)|g"   \
 	-e "s|@TLP_VAR@|$(TLP_VAR)|g"
 
 INFILES = \

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ TLP_MAN    ?= /usr/share/man
 TLP_META   ?= /usr/share/metainfo
 TLP_RUN    ?= /run/tlp
 TLP_VAR    ?= /var/lib/tlp
+TLP_CUSTOMIZE    ?= /etc/default/tlp.d
 
 # Catenate DESTDIR to paths
 _SBIN  = $(DESTDIR)$(TLP_SBIN)
@@ -42,6 +43,7 @@ SED = sed \
 	-e "s|@TLP_FLIB@|$(TLP_FLIB)|g" \
 	-e "s|@TLP_ULIB@|$(TLP_ULIB)|g" \
 	-e "s|@TLP_CONF@|$(TLP_CONF)|g" \
+	-e "s|@TLP_CUSTOMIZE@|$(TLP_CUSTOMIZE)|g" \
 	-e "s|@TLP_RUN@|$(TLP_RUN)|g"   \
 	-e "s|@TLP_VAR@|$(TLP_VAR)|g"
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ TLP_MAN    ?= /usr/share/man
 TLP_META   ?= /usr/share/metainfo
 TLP_RUN    ?= /run/tlp
 TLP_VAR    ?= /var/lib/tlp
-TLP_CUSTOMIZE    ?= /etc/default/tlp.d
+TLP_CUSTOMIZE    ?= /etc/tlp.conf.d
 
 # Catenate DESTDIR to paths
 _SBIN  = $(DESTDIR)$(TLP_SBIN)

--- a/default
+++ b/default
@@ -9,6 +9,7 @@
 #   or disabled by a leading '#'; use PARAM="" to disable intrinsic defaults for
 #   parameters with text string values
 # - Default <none>: do nothing or use kernel/hardware defaults
+# - The setting may be overrided by configurations in /etc/tlp.conf.d
 
 # Set to 0 to disable, 1 to enable TLP.
 # Default: 0

--- a/func.d/20-tlp-func-usb
+++ b/func.d/20-tlp-func-usb
@@ -264,7 +264,7 @@ set_usb_suspend () { # enable/disable usb autosuspend for all devices
         [ "$1" = "1" ] && echo "USB autosuspend settings applied."
         echo_debug "usb" "set_usb_suspend.done"
     else
-        [ "$1" = "1" ] && echo "Error: USB autosuspend is disabled. Set USB_AUTOSUSPEND=1 in $CONFFILE." 1>&2
+        [ "$1" = "1" ] && echo "Error: USB autosuspend is disabled. Set USB_AUTOSUSPEND=1 in $CUSTOMIZECONFDIR." 1>&2
         echo_debug "usb" "set_usb_suspend.not_configured"
 
     fi

--- a/man/tlp.8
+++ b/man/tlp.8
@@ -103,6 +103,11 @@ tlp recalibrate BAT0
 .I /etc/default/tlp
 .RS
 System-wide configuration file containing all power saving settings.
+.RE
+.PP
+.I /etc/default/tlp.d/
+.RS
+Custimized System-wide configuration files containing all power saving settings.
 .
 .SH EXIT STATUS
 On success, 0 is returned, a non-zero failure code otherwise.

--- a/man/tlp.8
+++ b/man/tlp.8
@@ -105,7 +105,7 @@ tlp recalibrate BAT0
 System-wide configuration file containing all power saving settings.
 .RE
 .PP
-.I /etc/default/tlp.d/
+.I /etc/tlp.conf.d/
 .RS
 Custimized System-wide configuration files containing all power saving settings.
 .

--- a/man/tlp.8
+++ b/man/tlp.8
@@ -102,12 +102,17 @@ tlp recalibrate BAT0
 .SH FILES
 .I /etc/default/tlp
 .RS
-System-wide configuration file containing all power saving settings.
+System-wide default configuration file containing all power saving settings.
 .RE
 .PP
 .I /etc/tlp.conf.d/
 .RS
-Custimized System-wide configuration files containing all power saving settings.
+Custimized system-wide configuration files which will override /etc/default/tlp.
+.RE
+.PP
+.I /run/tlp/tlp.conf
+.RS
+Runtime system-wide configuration file which is the final setting.
 .
 .SH EXIT STATUS
 On success, 0 is returned, a non-zero failure code otherwise.

--- a/man/tlp.8
+++ b/man/tlp.8
@@ -100,19 +100,29 @@ Recalibrate the main battery:
 tlp recalibrate BAT0
 .
 .SH FILES
-.I /etc/default/tlp
+.I /usr/share/tlp/defaults.conf
 .RS
 System-wide default configuration file containing all power saving settings.
 .RE
 .PP
 .I /etc/tlp.conf.d/
 .RS
-Custimized system-wide configuration files which will override /etc/default/tlp.
+Customized system-wide configuration files which will override /usr/share/tlp/defaults.conf.
+.RE
+.PP
+.I /etc/tlp.conf
+.RS
+As a template, user can uncomment changes here to override setting in above files.
+.RE
+.PP
+.I /etc/default/tlp
+.RS
+For backward compatibility. This outdated file will override all above configuration files.
 .RE
 .PP
 .I /run/tlp/tlp.conf
 .RS
-Runtime system-wide configuration file which is the final setting.
+Generated runtime system-wide configuration file which is the final setting.
 .
 .SH EXIT STATUS
 On success, 0 is returned, a non-zero failure code otherwise.

--- a/template
+++ b/template
@@ -1,0 +1,395 @@
+## ------------------------------------------------------------------------------
+## tlp - Parameters for power saving
+## See full explanation: https://linrunner.de/en/tlp/docs/tlp-configuration.html
+#
+## Notes:
+## - Some parameters are disabled, remove the leading '#' to enable # them;
+##   shown values are suggestions not defaults
+## - Default *: intrinsic default that is effective when the parameter is missing
+##   or disabled by a leading '#'; use PARAM="" to disable intrinsic defaults for
+##   parameters with text string values
+## - Default <none>: do nothing or use kernel/hardware defaults
+## - The setting may be overrided by configurations in /etc/tlp.conf.d
+#
+## Set to 0 to disable, 1 to enable TLP.
+## Default: 0
+#TLP_ENABLE=1
+#
+## Operation mode when no power supply can be detected: AC, BAT.
+## Concerns some desktop and embedded hardware only.
+## Default: <none>
+#TLP_DEFAULT_MODE=AC
+#
+## Operation mode select: 0=depend on power source, 1=always use TLP_DEFAULT_MODE
+## Hint: use in conjunction with TLP_DEFAULT_MODE=BAT for BAT settings on AC.
+## Default: 0
+#TLP_PERSISTENT_DEFAULT=0
+#
+## Seconds laptop mode has to wait after the disk goes idle before doing a sync.
+## Non-zero value enables, zero disables laptop mode.
+## Default: 0 (AC), 2 (BAT)
+#DISK_IDLE_SECS_ON_AC=0
+#DISK_IDLE_SECS_ON_BAT=2
+#
+## Dirty page values (timeouts in secs).
+## Default: 15 (AC + BAT)
+#MAX_LOST_WORK_SECS_ON_AC=15
+#MAX_LOST_WORK_SECS_ON_BAT=60
+#
+## Note: CPU parameters below are disabled by default, remove the leading #
+## to enable them, otherwise kernel defaults will be used.
+#
+## Select a CPU frequency scaling governor.
+## Intel Core i processor with intel_pstate driver:
+##   powersave(*), performance.
+## Other hardware with acpi-cpufreq driver:
+##   ondemand(*), powersave, performance, conservative, schedutil.
+## (*) is recommended.
+## Use tlp-stat -p to show the active driver and available governors.
+## Important:
+##   powersave for intel_pstate and ondemand for acpi-cpufreq are power
+##   efficient for *almost all* workloads and therefore kernel and most
+##   distributions have chosen them as defaults. If you still want to change,
+##   you should know what you're doing!
+## Default: <none>
+##CPU_SCALING_GOVERNOR_ON_AC=powersave
+##CPU_SCALING_GOVERNOR_ON_BAT=powersave
+#
+## Set the min/max frequency available for the scaling governor.
+## Possible values depend on your CPU. For available frequencies see
+## the output of tlp-stat -p.
+## Default: <none>
+##CPU_SCALING_MIN_FREQ_ON_AC=0
+##CPU_SCALING_MAX_FREQ_ON_AC=0
+##CPU_SCALING_MIN_FREQ_ON_BAT=0
+##CPU_SCALING_MAX_FREQ_ON_BAT=0
+#
+## Set Intel CPU energy/performance policies HWP.EPP and EPB:
+##   performance, balance_performance, default, balance_power, power
+## Values are given in order of increasing power saving.
+## Notes:
+## - Requires an Intel Core i processor
+## - HWP.EPP requires kernel 4.10 and intel_pstate driver
+## - EPB requires kernel 5.2 or module msr and x86_energy_perf_policy
+##   from linux-tools
+## - When HWP.EPP is available, EPB is not set
+## Default: <none>
+#CPU_ENERGY_PERF_POLICY_ON_AC=balance_performance
+#CPU_ENERGY_PERF_POLICY_ON_BAT=power
+#
+## Set Intel CPU P-state performance: 0..100 (%).
+## Limit the max/min P-state to control the power dissipation of the CPU.
+## Values are stated as a percentage of the available performance.
+## Requires an Intel Core i processor with intel_pstate driver.
+## Default: <none>
+##CPU_MIN_PERF_ON_AC=0
+##CPU_MAX_PERF_ON_AC=100
+##CPU_MIN_PERF_ON_BAT=0
+##CPU_MAX_PERF_ON_BAT=30
+#
+## Set the CPU "turbo boost" feature: 0=disable, 1=allow
+## Requires an Intel Core i processor.
+## Important:
+## - This may conflict with your distribution's governor settings
+## - A value of 1 does *not* activate boosting, it just allows it
+## Default: <none>
+##CPU_BOOST_ON_AC=1
+##CPU_BOOST_ON_BAT=0
+#
+## Minimize number of used CPU cores/hyper-threads under light load conditions:
+##   0=disable, 1=enable.
+## Default: <none>
+#SCHED_POWERSAVE_ON_AC=0
+#SCHED_POWERSAVE_ON_BAT=1
+#
+## Kernel NMI Watchdog:
+##   0=disable (default, saves power), 1=enable (for kernel debugging only).
+## Default: <none>
+#NMI_WATCHDOG=0
+#
+## Change CPU voltages aka "undervolting" - Kernel with PHC patch required.
+## Frequency voltage pairs are written to:
+##   /sys/devices/system/cpu/cpu0/cpufreq/phc_controls
+## CAUTION: only use this, if you thoroughly understand what you are doing!
+## Default: <none>.
+##PHC_CONTROLS="F:V F:V F:V F:V"
+#
+## Disk devices; separate multiple devices with spaces.
+## Devices can be specified by disk ID also (lookup with: tlp diskid).
+## Note: DISK parameters below are effective only when this option is configured.
+## Default: "nvme0n1 sda"
+#DISK_DEVICES="nvme0n1 sda"
+#
+## Disk advanced power management level: 1..254, 255 (max saving, min, off).
+## Levels 1..127 may spin down the disk; 255 allowable on most drives.
+## Separate values for multiple disks with spaces. Use the special value 'keep'
+## to keep the hardware default for the particular disk.
+## Default: <none>
+#DISK_APM_LEVEL_ON_AC="254 254"
+#DISK_APM_LEVEL_ON_BAT="128 128"
+#
+## Hard disk spin down timeout:
+##   0:        spin down disabled
+##   1..240:   timeouts from 5s to 20min (in units of 5s)
+##   241..251: timeouts from 30min to 5.5 hours (in units of 30min)
+## See 'man hdparm' for details.
+## Separate values for multiple disks with spaces. Use the special value 'keep'
+## to keep the hardware default for the particular disk.
+## Default: <none>
+##DISK_SPINDOWN_TIMEOUT_ON_AC="0 0"
+##DISK_SPINDOWN_TIMEOUT_ON_BAT="0 0"
+#
+## Select I/O scheduler for the disk devices.
+## Multi queue (blk-mq) schedulers:
+##   mq-deadline(*), none, kyber, bfq
+## Single queue schedulers:
+##   deadline(*), cfq, bfq, noop
+## (*) recommended.
+## Separate values for multiple disks with spaces. Use the special value 'keep'
+## to keep the kernel default scheduler for the particular disk.
+## Notes:
+## - Multi queue (blk-mq) may need kernel boot option 'scsi_mod.use_blk_mq=1'
+##   and 'modprobe mq-deadline-iosched|kyber|bfq' on kernels < 5.0
+## - Single queue schedulers are legacy now and were removed together with
+##   the old block layer in kernel 5.0
+## Default: keep
+##DISK_IOSCHED="mq-deadline mq-deadline"
+#
+## AHCI link power management (ALPM) for disk devices:
+##   min_power, med_power_with_dipm(*), medium_power, max_performance.
+## (*) Kernel >= 4.15 required, then recommended.
+## Multiple values separated with spaces are tried sequentially until success.
+## Default: <none>
+#SATA_LINKPWR_ON_AC="med_power_with_dipm max_performance"
+#SATA_LINKPWR_ON_BAT="med_power_with_dipm min_power"
+#
+## Exclude host devices from AHCI link power management.
+## Separate multiple hosts with spaces.
+## Default: <none>
+##SATA_LINKPWR_BLACKLIST="host1"
+#
+## Runtime Power Management for AHCI host and disks devices:
+##   on=disable, auto=enable.
+## EXPERIMENTAL ** WARNING: auto may cause system lockups/data loss.
+## Default: <none>
+##AHCI_RUNTIME_PM_ON_AC=on
+##AHCI_RUNTIME_PM_ON_BAT=on
+#
+## Seconds of inactivity before disk is suspended.
+## Note: effective only when AHCI_RUNTIME_PM_ON_AC/BAT is activated.
+## Default: 15
+#AHCI_RUNTIME_PM_TIMEOUT=15
+#
+## PCI Express Active State Power Management (PCIe ASPM):
+##   default(*), performance, powersave, powersupersave.
+## (*) keeps BIOS ASPM defaults (recommended)
+## Default: <none>
+##PCIE_ASPM_ON_AC=default
+##PCIE_ASPM_ON_BAT=default
+#
+## Set the min/max/turbo frequency for the Intel GPU.
+## Possible values depend on your hardware. For available frequencies see
+## the output of tlp-stat -g.
+## Default: <none>
+##INTEL_GPU_MIN_FREQ_ON_AC=0
+##INTEL_GPU_MIN_FREQ_ON_BAT=0
+##INTEL_GPU_MAX_FREQ_ON_AC=0
+##INTEL_GPU_MAX_FREQ_ON_BAT=0
+##INTEL_GPU_BOOST_FREQ_ON_AC=0
+##INTEL_GPU_BOOST_FREQ_ON_BAT=0
+#
+## Radeon graphics clock speed (profile method): low, mid, high, auto, default;
+## auto = mid on BAT, high on AC.
+## Default: default
+#RADEON_POWER_PROFILE_ON_AC=default
+#RADEON_POWER_PROFILE_ON_BAT=default
+#
+## Radeon dynamic power management method (DPM): battery, performance.
+## Default: <none>
+#RADEON_DPM_STATE_ON_AC=performance
+#RADEON_DPM_STATE_ON_BAT=battery
+#
+## Radeon DPM performance level: auto, low, high; auto is recommended.
+## Note: effective only when RADEON_DPM_STATE_ON_AC/BAT is activated.
+## Default: auto
+#RADEON_DPM_PERF_LEVEL_ON_AC=auto
+#RADEON_DPM_PERF_LEVEL_ON_BAT=auto
+#
+## WiFi power saving mode: on=enable, off=disable; not supported by all adapters.
+## Default: <none>
+#WIFI_PWR_ON_AC=off
+#WIFI_PWR_ON_BAT=on
+#
+## Disable wake on LAN: Y/N.
+## Default: N
+#WOL_DISABLE=Y
+#
+## Enable audio power saving for Intel HDA, AC97 devices (timeout in secs).
+## A value of 0 disables, >=1 enables power saving (recommended: 1).
+## Default: <none>
+#SOUND_POWER_SAVE_ON_AC=0
+#SOUND_POWER_SAVE_ON_BAT=1
+#
+## Disable controller too (HDA only): Y/N.
+## Note: effective only when SOUND_POWER_SAVE_ON_AC/BAT is activated.
+## Default: Y
+#SOUND_POWER_SAVE_CONTROLLER=Y
+#
+## Power off optical drive in UltraBay/MediaBay: 0=disable, 1=enable.
+## Drive can be powered on again by releasing (and reinserting) the eject lever
+## or by pressing the disc eject button on newer models.
+## Note: an UltraBay/MediaBay hard disk is never powered off.
+## Default: 0
+#BAY_POWEROFF_ON_AC=0
+#BAY_POWEROFF_ON_BAT=0
+## Optical drive device to power off
+## Default: sr0
+#BAY_DEVICE="sr0"
+#
+## Runtime Power Management for PCI(e) bus devices: on=disable, auto=enable.
+## Default: <none>
+#RUNTIME_PM_ON_AC=on
+#RUNTIME_PM_ON_BAT=auto
+#
+## Exclude PCI(e) device adresses the following list from Runtime PM
+## (separate with spaces). Use lspci to get the adresses (1st column).
+## Default: <none>
+##RUNTIME_PM_BLACKLIST="bb:dd.f 11:22.3 44:55.6"
+#
+## Exclude PCI(e) devices assigned to the listed drivers from Runtime PM.
+## Default when unconfigured is "amdgpu nouveau nvidia radeon" which
+## prevents accidential power-on of dGPU in hybrid graphics setups.
+## Separate multiple drivers with spaces.
+## Default: "amdgpu mei_me nouveau nvidia pcieport radeon", use "" to disable
+## completely.
+##RUNTIME_PM_DRIVER_BLACKLIST="amdgpu mei_me nouveau nvidia pcieport radeon"
+#
+## Set to 0 to disable, 1 to enable USB autosuspend feature.
+## Default: 0
+#USB_AUTOSUSPEND=1
+#
+## Exclude listed devices from USB autosuspend (separate with spaces).
+## Use lsusb to get the ids.
+## Note: input devices (usbhid) are excluded automatically
+## Default: <none>
+##USB_BLACKLIST="1111:2222 3333:4444"
+#
+## Bluetooth devices are excluded from USB autosuspend:
+##   0=do not exclude, 1=exclude.
+## Default: 0
+#USB_BLACKLIST_BTUSB=0
+#
+## Phone devices are excluded from USB autosuspend:
+##   0=do not exclude, 1=exclude (enable charging).
+## Default: 0
+#USB_BLACKLIST_PHONE=0
+#
+## Printers are excluded from USB autosuspend:
+##   0=do not exclude, 1=exclude.
+## Default: 1
+#USB_BLACKLIST_PRINTER=1
+#
+## WWAN devices are excluded from USB autosuspend:
+##   0=do not exclude, 1=exclude.
+## Default: 0
+#USB_BLACKLIST_WWAN=0
+#
+## Include listed devices into USB autosuspend even if already excluded
+## by the blacklists above (separate with spaces). Use lsusb to get the ids.
+## Default: <none>
+##USB_WHITELIST="1111:2222 3333:4444"
+#
+## Set to 1 to disable autosuspend before shutdown, 0 to do nothing
+## (workaround for USB devices that cause shutdown problems).
+## Default: 0
+##USB_AUTOSUSPEND_DISABLE_ON_SHUTDOWN=1
+#
+## Restore radio device state (Bluetooth, WiFi, WWAN) from previous shutdown
+## on system startup: 0=disable, 1=enable.
+## Note: the parameters DEVICES_TO_DISABLE/ENABLE_ON_STARTUP/SHUTDOWN below
+##   are ignored when this is enabled.
+## Default: 0
+#RESTORE_DEVICE_STATE_ON_STARTUP=0
+#
+## Radio devices to disable on startup: bluetooth, wifi, wwan.
+## Separate multiple devices with spaces.
+## Default: <none>
+##DEVICES_TO_DISABLE_ON_STARTUP="bluetooth wifi wwan"
+#
+## Radio devices to enable on startup: bluetooth, wifi, wwan.
+## Separate multiple devices with spaces.
+## Default: <none>
+##DEVICES_TO_ENABLE_ON_STARTUP="wifi"
+#
+## Radio devices to disable on shutdown: bluetooth, wifi, wwan.
+## (workaround for devices that are blocking shutdown).
+## Default: <none>
+##DEVICES_TO_DISABLE_ON_SHUTDOWN="bluetooth wifi wwan"
+#
+## Radio devices to enable on shutdown: bluetooth, wifi, wwan.
+## (to prevent other operating systems from missing radios).
+## Default: <none>
+##DEVICES_TO_ENABLE_ON_SHUTDOWN="wwan"
+#
+## Radio devices to enable on AC: bluetooth, wifi, wwan.
+## Default: <none>
+##DEVICES_TO_ENABLE_ON_AC="bluetooth wifi wwan"
+#
+## Radio devices to disable on battery: bluetooth, wifi, wwan.
+## Default: <none>
+##DEVICES_TO_DISABLE_ON_BAT="bluetooth wifi wwan"
+#
+## Radio devices to disable on battery when not in use (not connected):
+##   bluetooth, wifi, wwan.
+## Default: <none>
+##DEVICES_TO_DISABLE_ON_BAT_NOT_IN_USE="bluetooth wifi wwan"
+#
+## Battery charge thresholds (ThinkPad only, tp-smapi or acpi-call kernel module
+## required). Charging starts when the remaining capacity falls below the
+## START_CHARGE_THRESH value and stops when exceeding the STOP_CHARGE_THRESH value.
+## Main / Internal battery (values in %)
+## Default: <none>
+##START_CHARGE_THRESH_BAT0=75
+##STOP_CHARGE_THRESH_BAT0=80
+## Ultrabay / Slice / Replaceable battery (values in %)
+## Default: <none>
+##START_CHARGE_THRESH_BAT1=75
+##STOP_CHARGE_THRESH_BAT1=80
+#
+## Restore charge thresholds when AC is unplugged: 0=disable, 1=enable.
+## Default: 0
+##RESTORE_THRESHOLDS_ON_BAT=1
+#
+## Battery feature drivers: 0=disable, 1=enable
+## Default: 1 (all)
+#NATACPI_ENABLE=1
+#TPACPI_ENABLE=1
+#TPSMAPI_ENABLE=1
+#
+## ------------------------------------------------------------------------------
+## tlp-rdw - Parameters for the radio device wizard
+## Possible devices: bluetooth, wifi, wwan.
+#
+## Notes:
+## - Parameters are disabled by default, remove the leading # to enable them
+## - Separate multiple radio devices with spaces
+#
+## Default: <none> (for all parameters below)
+#
+## Radio devices to disable on connect.
+##DEVICES_TO_DISABLE_ON_LAN_CONNECT="wifi wwan"
+##DEVICES_TO_DISABLE_ON_WIFI_CONNECT="wwan"
+##DEVICES_TO_DISABLE_ON_WWAN_CONNECT="wifi"
+#
+## Radio devices to enable on disconnect.
+##DEVICES_TO_ENABLE_ON_LAN_DISCONNECT="wifi wwan"
+##DEVICES_TO_ENABLE_ON_WIFI_DISCONNECT=""
+##DEVICES_TO_ENABLE_ON_WWAN_DISCONNECT=""
+#
+## Radio devices to enable/disable when docked.
+##DEVICES_TO_ENABLE_ON_DOCK=""
+##DEVICES_TO_DISABLE_ON_DOCK=""
+#
+## Radio devices to enable/disable when undocked.
+##DEVICES_TO_ENABLE_ON_UNDOCK="wifi"
+##DEVICES_TO_DISABLE_ON_UNDOCK=""

--- a/tlp-func-base.in
+++ b/tlp-func-base.in
@@ -15,6 +15,7 @@ readonly CONFFILE=@TLP_CONF@
 readonly RUNDIR=@TLP_RUN@
 readonly VARDIR=@TLP_VAR@
 readonly CUSTOMIZECONFDIR=@TLP_CUSTOMIZE@
+readonly RUNCONF=@TLP_RUNCONF@
 
 readonly FLOCK=flock
 readonly HDPARM=hdparm
@@ -407,6 +408,10 @@ echo "
 EOF
 . /tmp/tlp-runtime.conf.prepare
 rm /tmp/tlp-runtime.conf.prepare
+}
+
+generate_runtime_conf () { # generate runtime conf file based on default and customized configuration.
+    print_conf > $RUNCONF
 }
 
 parse_args4config () { # parse command-line arguments: everything after the

--- a/tlp-func-base.in
+++ b/tlp-func-base.in
@@ -14,6 +14,7 @@ readonly TLPVER="1.3.0-alpha.1"
 readonly CONFFILE=@TLP_CONF@
 readonly RUNDIR=@TLP_RUN@
 readonly VARDIR=@TLP_VAR@
+readonly CUSTOMIZECONFDIR=@TLP_CUSTOMIZE@
 
 readonly FLOCK=flock
 readonly HDPARM=hdparm
@@ -380,6 +381,34 @@ read_defaults () { # read config file
         return 1
     fi
 }
+
+read_customization () { # read customized config file
+    for i in $(find /etc/default/tlp.d -type f | sort); do
+        . $i
+    done
+    return 0
+}
+
+read_confs () { # read all config files
+    if read_defaults && read_customization;then
+        return 0
+    else
+        return $resule
+    fi
+
+}
+
+print_conf() { # print runtime conf based on default and customized configuration.
+read_confs
+cat <<EOF >/tmp/tlp-runtime.conf.prepare
+echo "
+`for i in $(grep -E -v "^#|^\s*$" /etc/default/tlp | awk -F'=' '{print $1}');do echo $i=\\'\\"\\$$i\\"\\';done`
+"
+EOF
+. /tmp/tlp-runtime.conf.prepare
+rm /tmp/tlp-runtime.conf.prepare
+}
+
 
 parse_args4config () { # parse command-line arguments: everything after the
                        # delimiter '--' is interpreted as a config parameter

--- a/tlp-func-base.in
+++ b/tlp-func-base.in
@@ -11,10 +11,12 @@
 
 readonly TLPVER="1.3.0-alpha.1"
 
-readonly CONFFILE=@TLP_CONF@
+readonly CONFFILE_DEF=@TLP_CONFDEF@
+readonly CONFFILE_TEMP=@TLP_CONFTEMP@
+readonly CONFFILE_OUTDATED=@TLP_CONFOUTDATED@
 readonly RUNDIR=@TLP_RUN@
 readonly VARDIR=@TLP_VAR@
-readonly CUSTOMIZECONFDIR=@TLP_CUSTOMIZE@
+readonly CUSTOMIZECONFDIR=@TLP_CONFD@
 readonly RUNCONF=@TLP_RUNCONF@
 
 readonly FLOCK=flock
@@ -160,7 +162,7 @@ check_tlp_enabled () { # check if TLP is enabled in config file
     if [ "$TLP_ENABLE" = "1" ]; then
         return 0
     else
-        [ "$1" = "1" ] && echo "Error: TLP power save is disabled. Set TLP_ENABLE=1 in $CONFFILE." 1>&2
+        [ "$1" = "1" ] && echo "Error: TLP power save is disabled. Set TLP_ENABLE=1 in configuration file." 1>&2
         return 1
     fi
 }
@@ -374,9 +376,9 @@ create_rundir () { # make sure $RUNDIR exists
 # --- Configuration
 
 read_defaults () { # read config file
-    if [ -f $CONFFILE ]; then
+    if [ -f $CONFFILE_DEF ]; then
         # shellcheck disable=SC1090
-        . $CONFFILE
+        . $CONFFILE_DEF
         return 0
     else
         return 1
@@ -384,17 +386,21 @@ read_defaults () { # read config file
 }
 
 read_customization () { # read customized config file
-    for i in $(find $CUSTOMIZECONFDIR -type f | sort); do
+    for i in $(find $CUSTOMIZECONFDIR -type f | sort) $CONFFILE_TEMP; do
         . $i
     done
     return 0
 }
 
 read_confs () { # read all config files
-    if read_defaults && read_customization;then
+    if read_defaults && read_customization; then
+        if [ -f $CONFFILE_OUTDATED ]; then
+            # shellcheck disable=SC1090
+            . $CONFFILE_OUTDATED
+        fi
         return 0
     else
-        return $resule
+        return 1
     fi
 
 }
@@ -403,7 +409,7 @@ print_conf () { # print runtime conf based on default and customized configurati
 read_confs
 cat <<EOF >/tmp/tlp-runtime.conf.prepare
 echo "
-`for i in $(grep -E -v "^#|^\s*$" /etc/default/tlp | awk -F'=' '{print $1}');do echo $i=\\'\\"\\$$i\\"\\';done`
+`for i in $(grep -E -v "^#|^\s*$" $CONFFILE_DEF | awk -F'=' '{print $1}');do echo $i=\\'\\"\\$$i\\"\\';done`
 "
 EOF
 . /tmp/tlp-runtime.conf.prepare
@@ -411,7 +417,9 @@ rm /tmp/tlp-runtime.conf.prepare
 }
 
 generate_runtime_conf () { # generate runtime conf file based on default and customized configuration.
+    mkdir -p $(dirname $RUNCONF)
     print_conf > $RUNCONF
+    chmod 444 $RUNCONF
 }
 
 parse_args4config () { # parse command-line arguments: everything after the

--- a/tlp-func-base.in
+++ b/tlp-func-base.in
@@ -383,7 +383,7 @@ read_defaults () { # read config file
 }
 
 read_customization () { # read customized config file
-    for i in $(find /etc/default/tlp.d -type f | sort); do
+    for i in $(find $CUSTOMIZECONFDIR -type f | sort); do
         . $i
     done
     return 0
@@ -398,7 +398,7 @@ read_confs () { # read all config files
 
 }
 
-print_conf() { # print runtime conf based on default and customized configuration.
+print_conf () { # print runtime conf based on default and customized configuration.
 read_confs
 cat <<EOF >/tmp/tlp-runtime.conf.prepare
 echo "
@@ -408,7 +408,6 @@ EOF
 . /tmp/tlp-runtime.conf.prepare
 rm /tmp/tlp-runtime.conf.prepare
 }
-
 
 parse_args4config () { # parse command-line arguments: everything after the
                        # delimiter '--' is interpreted as a config parameter

--- a/tlp-stat.in
+++ b/tlp-stat.in
@@ -205,7 +205,7 @@ add_sbin2path
 
 
 # check for and read conffile
-read_defaults; conf_present=$?
+read_confs; conf_present=$?
 parse_args "$@"
 parse_args4config "$@"
 : ${needs_root_priv:=1}
@@ -228,8 +228,8 @@ echo
 # --- show configuration
 if [ "$show_conf" = "1" ] || [ "$show_all" = "1" ]; then
     if [ $conf_present -eq 0 ]; then
-        echo "+++ Configured Settings: $CONFFILE"
-        grep -E -v '^#|^\s*$' $CONFFILE
+        echo "+++ Configured Settings: $CONFFILE $CUSTOMIZECONFDIR"
+        print_conf
         echo
     else
         echo "Error: config file $CONFFILE not present." 1>&2

--- a/tlp-stat.in
+++ b/tlp-stat.in
@@ -228,11 +228,11 @@ echo
 # --- show configuration
 if [ "$show_conf" = "1" ] || [ "$show_all" = "1" ]; then
     if [ $conf_present -eq 0 ]; then
-        echo "+++ Configured Settings: $CONFFILE $CUSTOMIZECONFDIR"
+        echo "+++ Configured Settings: $CONFFILE_DEF $CUSTOMIZECONFDIR"
         print_conf
         echo
     else
-        echo "Error: config file $CONFFILE not present." 1>&2
+        echo "Error: config file $CONFFILE_DEF not present." 1>&2
         echo
     fi
 fi # show_conf

--- a/tlp.in
+++ b/tlp.in
@@ -172,7 +172,7 @@ parse_args () { # parse command-line arguments
 
 # --- MAIN
 
-read_defaults
+read_confs
 parse_args "$@"
 parse_args4config "$@"
 check_tlp_enabled 1 || exit 1

--- a/tlp.in
+++ b/tlp.in
@@ -247,7 +247,7 @@ exitcode=0
 case "$_cmd" in
     init) # system initialization/shutdown: sysv, upstart, systemd, ...
         check_root
-
+        generate_runtime_conf
         # try to obtain lock (with timeout)
         locked=0
         if lock_tlp; then


### PR DESCRIPTION
followed the discussion https://github.com/linrunner/TLP/issues/432
and also refer to https://github.com/linrunner/TLP/issues/398

This patch target to fix problems:
1. user can put their customized configuration to override default one. And the customize should be reserved every time tlp package updated.
1.1. customized configuration in /etc/tlp.conf.d will be read by numerical older.
e.g. /etc/tlp.conf.d/02-my-customize override  /etc/tlp.conf.d/01-estar override /etc/default/tlp

2. have the ability to get runtime configuration by tlp-state

3. let external utility ex. TLPUI can still refer to a single file for a runtime setting. (added a /run/tlp/tlp.conf)

take an example:
/etc/tlp.conf.d
|- [01_estar](http://paste.ubuntu.com/p/HpRB82v7ph/)
|- [02_estar](http://paste.ubuntu.com/p/wXQcjR6pTC/)
Then get runtime configuration file by tlp systemd service:
[/run/tlp/tlp.conf](http://paste.ubuntu.com/p/JM5WSDjfnp/)

And tlp-state also get the runtime config setting as well:
http://paste.ubuntu.com/p/TH3mdkSFMv/
