### PR TITLE
update default config: add reference to thinkpad_acpi module

### DIFF
--- a/default
+++ b/default
@@ -343,8 +343,11 @@ RESTORE_DEVICE_STATE_ON_STARTUP=0
 # Default: <none>
 #DEVICES_TO_DISABLE_ON_BAT_NOT_IN_USE="bluetooth wifi wwan"
 
-# Battery charge thresholds (ThinkPad only, tp-smapi or acpi-call kernel module
-# required). Charging starts when the remaining capacity falls below the
+# Battery charge thresholds (ThinkPad only), may need additional kernel modules:
+#   older models (until about 2012): tp-smapi kernel module required.
+#   newer models, Linux < 4.17: acpi-call kernel module required.
+#   newer models, Linux >= 4.17: native support available.
+# Charging starts when the remaining capacity falls below the
 # START_CHARGE_THRESH value and stops when exceeding the STOP_CHARGE_THRESH value.
 # Main / Internal battery (values in %)
 # Default: <none>


### PR DESCRIPTION
Since Linux 4.17, thinkpad_acpi may also be used to set batterty charging thresholds. This functionality has been implemented in TLP as well. Thus, no custom kernel modules are needed anymore for newer models which eases installation with SecureBoot enabled. Therefore add a reference to the default config.