### PR TITLE
tlp.service: don't wait for NetworkManager.service

### DIFF
--- a/tlp.service.in
+++ b/tlp.service.in
@@ -5,7 +5,7 @@
 
 [Unit]
 Description=TLP system startup/shutdown
-After=NetworkManager.service
+After=multi-user.target
 Before=shutdown.target
 Documentation=https://linrunner.de/tlp
 


### PR DESCRIPTION
commit 03e2447 was supposed to remove dependence on NetworkManager.service but instead it removed multi-user.target