### PR TITLE
Support systemctl reload

### DIFF
--- a/tlp.service.in
+++ b/tlp.service.in
@@ -13,6 +13,7 @@ Documentation=https://linrunner.de/tlp
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=@TLP_SBIN@/tlp init start
+ExecReload=@TLP_SBIN@/tlp start
 ExecStop=@TLP_SBIN@/tlp init stop
 
 [Install]


### PR DESCRIPTION
I saw the discussion in https://github.com/d4nj1/TLPUI/issues/59
> BUT, restarting the service is not the right way to apply changed settings. A service restart could cut your wifi (depending on the config), that's not what users expect i guess.
> 
> PLEASE use tlp start for that purpose.

Editing the service according to that. Am I correct in that no `tlp stop` is needed before the `tlp start`?

This will be used by the commands `systemctl reload` and `systemctl reload-or-restart`