### PR TITLE
makefile: use short-style option for install(1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ install-tlp: all
 	install -m 755 tlp-run-on $(_BIN)/run-on-ac
 	ln -sf run-on-ac $(_BIN)/run-on-bat
 	install -m 755 tlp-stat $(_BIN)/
-	install -D -m 755 --target-directory $(_TLIB)/func.d func.d/*
+	install -D -m 755 -t $(_TLIB)/func.d func.d/*
 	install -m 755 tlp-func-base $(_TLIB)/
 	install -m 755 tlp-pcilist $(_TLIB)/
 	install -m 755 tlp-readconfs $(_TLIB)/


### PR DESCRIPTION
I realized when I was mucking around with the package template on Alpine that in the makefile there is an instance of `install --target-directory ...`. This is a GNU-style option that is only available in GNU's implementation of `install`. Other implementations (such as `busybox`) also have this option but only have the equivalent short option `-t`. So this removes the need for GNU coreutils to be installed on GNU-less systems just to install the package :P