### PR TITLE
Allow using integer value for setting HWP.EPP

### DIFF
--- a/func.d/10-tlp-func-cpu
+++ b/func.d/10-tlp-func-cpu
@@ -157,6 +157,9 @@ set_intel_cpu_perf_policy () {
             performance|balance_performance|default|balance_power|power) # OK --> continue
                 ;;
 
+            [0-9]|[0-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]) # HWP.EPP accepts 0 to 255 --> continue
+                ;;
+
             *) # invalid setting
                 echo_debug "pm" "set_intel_cpu_perf_policy($1).hwp_epp.invalid: perf=$perf"
                 return 0


### PR DESCRIPTION
In addition to the predetermined strings such as `performance` and `balance_power`, HWP.EPP also accepts an integer value of 0 to 255. This pull request considers such integers as valid.

The difference between `performance` and the next level `balance_performance` is a lot (0 to 128), whereas on my use case, 32 would be the perfect value.