### PR TITLE
Fix order of min/max frequency bounds vs pct

### DIFF
--- a/tlp.in
+++ b/tlp.in
@@ -22,9 +22,9 @@ apply_common_settings () { # apply settings common to all modes
     set_laptopmode $1
     set_dirty_parms $1
     set_cpu_scaling_governor $1
-    set_cpu_scaling_min_max_freq $1
     set_intel_cpu_perf_policy $1
     set_intel_cpu_perf_pct $1
+    set_cpu_scaling_min_max_freq $1    
     set_cpu_boost_all $1
     set_intel_cpu_hwp_dyn_boost $1
     set_sched_powersave $1


### PR DESCRIPTION
When setting parameter out of range of existing max_pct limitation, the frequency is rounded. Therefore the write, even if successful is ignored,
Found on TigerLake with the following configuration items, and when switching between ac/bat/ac

CPU_SCALING_GOVERNOR_ON_AC=performance
CPU_SCALING_MAX_FREQ_ON_AC=2600000
CPU_SCALING_MAX_FREQ_ON_BAT=1500000
CPU_ENERGY_PERF_POLICY_ON_AC=balance_performance
CPU_ENERGY_PERF_POLICY_ON_BAT=powersave
CPU_MAX_PERF_ON_AC=100
CPU_MAX_PERF_ON_BAT=40