### PR TITLE
Issue #573: Fix power_mode not changing from AC to battery.

### DIFF
--- a/tlp-func-base.in
+++ b/tlp-func-base.in
@@ -786,7 +786,7 @@ get_sys_power_supply () {
                     # when command is 'tlp auto', not "Discharging" might be caused by lagging battery status updates
                     # --> recheck every 0.1 secs for 0.8 secs (or user value in deciseconds) max
                     wait="$X_PS_WAIT_DS"
-                    is_uint "$wait" 2 || wait=8
+                    is_uint "$wait" 2 || wait=15
                     echo_debug "ps" "get_sys_power_supply(${psrc_name}).bat_not_discharging_recheck: bs=$bs; syspwr=$_syspwr; wait=$wait"
                     while [ $wait -gt 0 ]; do
                         sleep 0.1


### PR DESCRIPTION
#573 
When get_sys_power_supply checks for battery discharging status, it does not wait long enough for status to be updated after switching from AC to battery. Changed the wait time from .8 to 1.5 seconds to give plenty of time for discharge status to update. 
Tested on 2010 Macbook Pro.