### PR TITLE
README.d: Fix URL for documentation.

### DIFF
--- a/README.d
+++ b/README.d
@@ -1,5 +1,5 @@
 This directory is intended to contain drop-in customizations for TLP.
-See full explanation: https://linrunner.de/settings
+See full explanation: https://linrunner.de/tlp/settings
 
 The naming scheme is 00-name.conf, the files are read in lexical (aphabetical)
 order.


### PR DESCRIPTION
I just noticed that the old URL pointed to the wrong location, resulting in a 404 error. Now the URL is in sync with the one in tlp.conf.