### PR TITLE
Deny autosuspend of NVidia jetson recovery mode devices by default

### DIFF
--- a/tlp.conf
+++ b/tlp.conf
@@ -384,9 +384,9 @@
 # Use lsusb to get the ids.
 # Note: input devices (usbhid) and libsane-supported scanners are excluded
 # automatically.
-# Default: <none>
+# Default: 0955:7c18 (NVidia Jetson boards in recovery mode)
 
-#USB_DENYLIST="1111:2222 3333:4444"
+USB_DENYLIST="0955:7c18"
 
 # Exclude audio devices from USB autosuspend:
 #   0=do not exclude, 1=exclude.


### PR DESCRIPTION
There is a conflict between tlp and NVidia jetson devices in recovery mode. It has been reported that trying to flash the devices via USB with tlp installed fails: https://forums.developer.nvidia.com/t/sdk-manager-could-not-detect-target-hardware/71797/60 (see mostly the end of the discussion). Adding the 0955:7c18 ID to denylist fixes the issue.

I'm not sure if this is the best place to put this USB ID, maybe there is a better way to do it?