### PR TITLE
implement System Sleep methods configuration

### DIFF
--- a/func.d/05-tlp-func-pm
+++ b/func.d/05-tlp-func-pm
@@ -223,3 +223,35 @@ disable_wake_on_lan () {  # disable WOL
 
     return 0
 }
+
+# --- Set suspend method
+    
+set_mem_sleep () {
+    # $1: 0=ac mode, 1=battery mode
+        
+    local susp
+        
+    if [ "$1" = "1" ]; then
+        susp=${MEM_SLEEP_ON_BAT:-}
+    else
+        susp=${MEM_SLEEP_ON_AC:-}
+    fi
+
+    if [ -z "$susp" ]; then
+        # do nothing if unconfigured
+        echo_debug "pm" "set_mem_sleep($1).not_configured"
+        return 0
+    fi
+
+    if [ -f /sys/power/mem_sleep ]; then
+        if write_sysf "$susp" /sys/power/mem_sleep; then
+            echo_debug "pm" "set_mem_sleep($1): $susp"
+        else
+            echo_debug "pm" "set_mem_sleep($1).disabled_by_kernel"
+        fi
+    else
+        echo_debug "pm" "set_mem_sleep($1).not_available"
+    fi
+
+    return 0
+}

--- a/tlp.conf
+++ b/tlp.conf
@@ -169,6 +169,16 @@
 #PLATFORM_PROFILE_ON_AC=performance
 #PLATFORM_PROFILE_ON_BAT=low-power
 
+# System suspend method
+# 's2idle' - S0 Suspend-To-Idle: a generic, pure software, light-weight, system sleep state.
+# 'deep' - S3 Suspend-to-RAM: this state, if supported, offers significant power savings as
+#               everything in the system is put into a low-power state, except for memory
+# https://www.kernel.org/doc/Documentation/power/states.txt
+# Default: <none> - use kernel default
+
+#MEM_SLEEP_ON_AC=s2idle
+#MEM_SLEEP_ON_BAT=deep
+
 # Define disk devices on which the following DISK/AHCI_RUNTIME parameters act.
 # Separate multiple devices with spaces.
 # Devices can be specified by disk ID also (lookup with: tlp diskid).

--- a/tlp.in
+++ b/tlp.in
@@ -30,6 +30,7 @@ apply_common_settings () { # apply settings common to all modes
     set_intel_cpu_hwp_dyn_boost $1
     set_sched_powersave $1
     set_nmi_watchdog
+    set_mem_sleep $1
     set_ahci_port_runtime_pm $1
     set_runtime_pm $1
     set_ahci_disk_runtime_pm $1


### PR DESCRIPTION
Different memory sleep configurations could be used for AC or BAT mode,
i.e. 's2idle' gives fast resume when on AC power, while 'deep' could give more
conservative battery usage suspending unplugged laptop.
Configuration options are used to control sleep mode `MEM_SLEEP_ON_AC`, `MEM_SLEEP_ON_BAT`
By default kernel preferred method is used.

I'm not sure I get the idea of TLP's code style, so let me know if it requires any adjustment or more detailed description somewhere.