### PR TITLE
Better documentation for the CPU_MAX_PERF settings

### DIFF
--- a/tlp.conf.in
+++ b/tlp.conf.in
@@ -128,6 +128,10 @@
 # Values are stated as a percentage of the available performance.
 # Requires Intel Core i 2nd gen. or newer CPU with intel_pstate or
 # intel_cpufreq driver.
+# Notes:
+# - Min/max frequencies should always be specified for both AC *and* BAT
+#     e.g. not setting the AC values results in BAT values used when switching
+#     from battery to AC power
 # Default: <none>
 
 #CPU_MIN_PERF_ON_AC=0


### PR DESCRIPTION
Multiple sources over the internet suggest using the `CPU_MAX_PERF_ON_BAT` setting, but none specify that you should set the `CPU_MAX_PERF_ON_AC` as well. 

Usually you would set some lower value for the `CPU_MAX_PERF_ON_BAT` like 30.
Not setting the `CPU_MAX_PERF_ON_AC` while the `CPU_MAX_PERF_ON_BAT` is set results in the `CPU_MAX_PERF_ON_BAT` still being applied to your system even after you switch from the battery to AC power supply. This degrades the system performance on AC and it's not obvious to the user that on AC they are still using the setting applied with `CPU_MAX_PERF_ON_BAT`.

This PR adds a documentation note to the default *tlp.conf* to clarify this. 