### PR TITLE
fix support for raptor lake dynamic frequency

### DIFF
--- a/func.d/10-tlp-func-cpu
+++ b/func.d/10-tlp-func-cpu
@@ -13,6 +13,7 @@ readonly CPUD=/sys/devices/system/cpu
 readonly CPU_BOOST_ALL_CTRL=${CPUD}/cpufreq/boost
 readonly INTEL_PSTATED=${CPUD}/intel_pstate
 readonly AMD_PSTATED=${CPUD}/amd_pstate
+readonly INTEL_PSTATE_STATUS=$INTEL_PSTATED/status
 readonly CPU_MIN_PERF_PCT=$INTEL_PSTATED/min_perf_pct
 readonly CPU_MAX_PERF_PCT=$INTEL_PSTATED/max_perf_pct
 readonly CPU_TURBO_PSTATE=$INTEL_PSTATED/no_turbo
@@ -472,4 +473,13 @@ set_platform_profile () { # set platform profile
     fi
 
     return 0
+}
+
+intel_workaround_freq_change () {
+    if check_intel_pstate; then
+        #restart the hw frequency switching engine
+        write_sysf active $INTEL_PSTATE_STATUS
+        sleep 0.1
+        write_sysf passive $INTEL_PSTATE_STATUS
+    fi
 }

--- a/tlp.in
+++ b/tlp.in
@@ -41,6 +41,7 @@ apply_common_settings () { # apply settings common to all modes
     set_wifi_power_mode "$1"
     disable_wake_on_lan
     set_sound_power_mode "$1"
+    intel_workaround_freq_change
 
     return 0
 }


### PR DESCRIPTION
After switching from my lenovo x1 yoga gen 6 (tiger lake 1135) to lenovo x1 yoga gen 8 (raptor lake) I had the bad surprise of a laptop draining battery faster!
After some digging I found out the frequency management was off. I also discovered that we need to toggle active/passive intel pstate status for the dynamic frequency to be reenabled. Although it's probably not the root cause, I was not ready for a Linux kernel side digging.

My tlp.conf for fan less experience contains:
```
CPU_SCALING_GOVERNOR_ON_AC=powersave
CPU_SCALING_GOVERNOR_ON_BAT=powersave
CPU_SCALING_MAX_FREQ_ON_AC=2000000
CPU_SCALING_MAX_FREQ_ON_BAT=400000
CPU_ENERGY_PERF_POLICY_ON_AC=power
CPU_ENERGY_PERF_POLICY_ON_BAT=power
CPU_HWP_DYN_BOOST_ON_AC=0
CPU_HWP_DYN_BOOST_ON_BAT=0
CPU_MIN_PERF_ON_AC=0
CPU_MAX_PERF_ON_AC=80
CPU_MIN_PERF_ON_BAT=0
CPU_MAX_PERF_ON_BAT=40
SCHED_POWERSAVE_ON_AC=1
SCHED_POWERSAVE_ON_BAT=1
CPU_BOOST_ON_AC=1
CPU_BOOST_ON_BAT=1
INTEL_GPU_MIN_FREQ_ON_AC=300
INTEL_GPU_MIN_FREQ_ON_BAT=300
INTEL_GPU_MAX_FREQ_ON_AC=500
INTEL_GPU_MAX_FREQ_ON_BAT=300
INTEL_GPU_BOOST_FREQ_ON_AC=500
INTEL_GPU_BOOST_FREQ_ON_BAT=300
```

And with the pull request patch, the dynamic frequency is working like a charm. Hope it could help others.