### PR TITLE
fix: grep warning: stray \ before -

### DIFF
--- a/func.d/15-tlp-func-disk
+++ b/func.d/15-tlp-func-disk
@@ -206,7 +206,7 @@ show_disk_ids () { # show disk id's
     local dev
 
     { # iterate SATA and NVMe disks
-        for dev in $(glob_files '/*' /dev/disk/by-id/ | sed -rn 's/.*\/((ata|ieee1394|nvme|usb))/\1/p' | grep -E -v '(^nvme-eui|\-part[1-9]+)'); do
+        for dev in $(glob_files '/*' /dev/disk/by-id/ | sed -rn 's/.*\/((ata|ieee1394|nvme|usb))/\1/p' | grep -E -v '(^nvme-eui|-part[1-9]+)'); do
             if [ -n "$dev" ]; then
                 get_disk_dev "$dev" && printf '%s: %s\n' "$_disk_dev" "$_disk_id"
             fi


### PR DESCRIPTION
See: [grep: warn about stray backslashes]

[grep: warn about stray backslashes]: https://git.savannah.gnu.org/cgit/grep.git/commit/?id=e7f8e8eb1fd41b308ee10741bbd8068acc1847c2