### PR TITLE
W510 battery care fix

### DIFF
--- a/bat.d/05-thinkpad
+++ b/bat.d/05-thinkpad
@@ -10,7 +10,7 @@
 # --- Hardware Detection
 readonly SMAPIBATDIR=/sys/devices/platform/smapi
 
-readonly RE_TPSMAPI_ONLY='^(Edge( 13.*)?|G41|R[56][012][eip]?|R[45]00|SL[45]10|T23|T[346][0123][p]?|T[45][01]0[s]?|W[57]0[01]|X[346][012][s]?( Tablet)?|X1[02]0e|X[23]0[01][s]?( Tablet)?|Z6[01][mpt])$'
+readonly RE_TPSMAPI_ONLY='^(Edge( 13.*)?|G41|R[56][012][eip]?|R[45]00|SL[45]10|T23|T[346][0123][p]?|T[45][01]0[s]?|W[57][01][01]|X[346][012][s]?( Tablet)?|X1[02]0e|X[23]0[01][s]?( Tablet)?|Z6[01][mpt])$'
 readonly RE_TPSMAPI_AND_TPACPI='^(X1|X220[s]?( Tablet)?|T[45]20[s]?|W520)$'
 readonly RE_TP_NONE='^(L[45]20|L512|SL[345]00|X121e)$'
 


### PR DESCRIPTION
The Thinkpad W510 is a thinkpad-legacy device but was not in the TPSMAPI_ONLY list, so tlp was not able to set charge thresholds. Now it works!