### PR TITLE
Add Fish completion for runon commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,8 @@ ifneq ($(TLP_NO_FISHCOMP),1)
 	ln -sf tlp.fish $(_FISHCPL)/nfc.fish
 	ln -sf tlp.fish $(_FISHCPL)/wifi.fish
 	ln -sf tlp.fish $(_FISHCPL)/wwan.fish
+	ln -sf tlp.fish $(_FISHCPL)/run-on-ac.fish
+	ln -sf tlp.fish $(_FISHCPL)/run-on-bat.fish
 endif
 	install -D -m 644 de.linrunner.tlp.metainfo.xml $(_META)/de.linrunner.tlp.metainfo.xml
 	install -d -m 755 $(_VAR)
@@ -271,6 +273,8 @@ uninstall-tlp:
 	rm -f $(_FISHCPL)/nfc.fish
 	rm -f $(_FISHCPL)/wifi.fish
 	rm -f $(_FISHCPL)/wwan.fish
+	rm -f $(_FISHCPL)/run-on-ac.fish
+	rm -f $(_FISHCPL)/run-on-bat.fish
 	rm -f $(_META)/de.linrunner.tlp.metainfo.xml
 	rm -r $(_VAR)
 

--- a/completion/fish/tlp.fish
+++ b/completion/fish/tlp.fish
@@ -1,8 +1,9 @@
-# Fish shell completion for tlp and radio device command: bluetooth nfc wifi wwan
+# Fish shell completion for tlp, radio device command: bluetooth nfc wifi wwan, and run-on command: run-on-ac run-on-bat
 
 set -l tlp_commands start bat ac usb bayoff setcharge fullcharge discharge recalibrate chargeonce diskid
 set -l tlp_rf_devices bluetooth nfc wifi wwan
 set -l tlp_rf_devices_commands on off toggle
+set -l runon_commands run-on-ac run-on-bat
 
 set -l current_command (status basename | path change-extension '')
 
@@ -37,4 +38,8 @@ if contains $current_command $tlp_rf_devices
     complete -c $current_command -n "not __fish_seen_subcommand_from $tlp_rf_devices_commands" -a off -d 'Switch device off'
     complete -c $current_command -n "not __fish_seen_subcommand_from $tlp_rf_devices_commands" -a toggle -d 'Toggle device state'
     complete -c $current_command -n "not __fish_seen_subcommand_from $tlp_rf_devices_commands" -l version -d 'Print TLP version'
+end
+
+if contains $current_command $runon_commands
+    complete -c $current_command -xa "(__fish_complete_subcommand)"
 end


### PR DESCRIPTION
Fish completion for run-on commands which are missing in the previous PR:
- `run-on-ac`
- `run-on-bat`

After this PR is merged, all commands provided by tlp and tlp-rdw currently will have their own completions in the Fish shell.