### PR TITLE
portable timeout for flock

### DIFF
--- a/tlp-func-base.in
+++ b/tlp-func-base.in
@@ -400,7 +400,7 @@ lock_tlp () { # get exclusive lock: blocking with timeout
     # open file for writing and attach fd 9
     # when successful lock fd 9 exclusive and blocking
     # wait $LOCKTIMEOUT secs to obtain the lock
-    if { exec 9> "${LOCKFILE}_${1:-tlp}" ; } 2> /dev/null && $FLOCK -x -w $LOCKTIMEOUT 9 ; then
+    if { exec 9> "${LOCKFILE}_${1:-tlp}" ; } 2> /dev/null && timeout $LOCKTIMEOUT $FLOCK -x 9 ; then
         echo_debug "lock" "lock_tlp($1).success"
         return 0
     else


### PR DESCRIPTION
Busybox `flock` does not support the `-w` option, and as such initialising `tlp` fails on systems using busybox utils. What I've done is use the `timeout` command instead of relying on `flock` itself.

I believe using portable options is the way to go.