### PR TITLE
Ignore hid-playstation batteries

### DIFF
--- a/tlp-func-base.in
+++ b/tlp-func-base.in
@@ -46,7 +46,7 @@ readonly TPACPID=/sys/devices/platform/thinkpad_acpi
 readonly RE_PARAM='^[A-Z_]+[0-9]*=[-0-9a-zA-Z _.:]*$'
 
 # power supplies: ignore MacBook Pro 2017 sbs-charger, hid devices, ThinkPad X13s ARM qcom-battmgr-ac
-readonly RE_PS_IGNORE='sbs-charger|hidpp_battery|hid-|qcom-battmgr-ac'
+readonly RE_PS_IGNORE='sbs-charger|hidpp_battery|hid-|ps-controller-battery-|qcom-battmgr-ac'
 
 readonly DEBUG_TAGS_ALL="arg bat cfg disk lock nm path pm ps rf run sysfs udev usb"
 

--- a/tlp-func-base.in
+++ b/tlp-func-base.in
@@ -46,7 +46,7 @@ readonly TPACPID=/sys/devices/platform/thinkpad_acpi
 readonly RE_PARAM='^[A-Z_]+[0-9]*=[-0-9a-zA-Z _.:]*$'
 
 # power supplies: ignore MacBook Pro 2017 sbs-charger, hid devices, ThinkPad X13s ARM qcom-battmgr-ac
-readonly RE_PS_IGNORE='sbs-charger|hidpp_battery|hid-|ps-controller-battery-|qcom-battmgr-ac'
+readonly RE_PS_IGNORE='sbs-charger|hidpp_battery|hid-|ps-controller-battery-|nintendo_switch_controller_battery_|qcom-battmgr-ac'
 
 readonly DEBUG_TAGS_ALL="arg bat cfg disk lock nm path pm ps rf run sysfs udev usb"
 


### PR DESCRIPTION
Initially confused as to why a disk was randomly spinning down when I never asked it to, I went through the five stages of grief as I realized that my DualShock 4 controller was causing TLP to think my *desktop computer* was running on battery.

Add the battery name prefix to the ignore list to fix the problem.