### PR TITLE
Fix typo: occurence -> occurrence in tlp.conf.in and changelog

### DIFF
--- a/changelog
+++ b/changelog
@@ -512,7 +512,7 @@
           1. Intrinsic defaults
           2. /etc/tlp.d/*.conf - Drop-in customization snippets
           3. /etc/tlp.conf     - User configuration
-        In case of identical parameters, the last occurence has precedence
+        In case of identical parameters, the last occurrence has precedence
       - Parse config files instead of sourcing --> no more shell expansion
     Battery Features, tlp-stat -b:
       - Charge thresholds: better checks for command line and configuration;

--- a/tlp.conf.in
+++ b/tlp.conf.in
@@ -12,7 +12,7 @@
 # 3. /etc/tlp.conf     - User configuration (this file)
 #
 # Notes:
-# - In case of identical parameters, the last occurence has precedence
+# - In case of identical parameters, the last occurrence has precedence
 # - This also means, parameters enabled here will override anything else
 # - However you may append values to a parameter already defined as intrinsic
 #   default or in a previously read file: use PARAMETER+="add values"


### PR DESCRIPTION
Fixed a typo in `tlp.conf.in` which I noticed in `/etc/tlp.conf` on my own system. The same typo appears in `changelog` so I fixed it there too. TLP is a very popular program, so in my opinion correct spelling and grammar in all documentation (including default config file comments) is of the utmost importance. 