### PR TITLE
Explicitly use daemon facility for logging

### DIFF
--- a/tlp-func-base.in
+++ b/tlp-func-base.in
@@ -105,7 +105,7 @@ echo_debug () { # write trace message to syslog if tag matches -- $1: tag; $2: m
     [ "$_nodebug" = "1" ] && return 0
 
     if wordinlist "$1" "$TLP_DEBUG"; then
-        $LOGGER -p debug -t "tlp" --id=$$ -- "$2" > /dev/null 2>&1
+        $LOGGER -p daemon.debug -t "tlp" --id=$$ -- "$2" > /dev/null 2>&1
     fi
 }
 
@@ -210,7 +210,7 @@ echo_message () {
 
         if [ -n "$msg" ]; then
             case "$TLP_WARN_LEVEL" in
-                1|3) $LOGGER -p "$class" -t "tlp" --id=$$ -- "$msg" > /dev/null 2>&1 ;;
+                1|3) $LOGGER -p "daemon.$class" -t "tlp" --id=$$ -- "$msg" > /dev/null 2>&1 ;;
             esac
         fi
     else

--- a/tlp-readconfs.in
+++ b/tlp-readconfs.in
@@ -63,7 +63,7 @@ sub printf_debug {
     if ( $trace2stderr) {
         printf STDERR @_;
     } elsif ( ! $notrace && $debug ) {
-        open (my $logpipe, "|-", "logger -p debug -t \"tlp\" --id=\$\$ --") || return 1;
+        open (my $logpipe, "|-", "logger -p daemon.debug -t \"tlp\" --id=\$\$ --") || return 1;
         printf {$logpipe} @_;
         close ($logpipe);
     }


### PR DESCRIPTION
Some systems comes with a bit different logger implementation (like the one from GNU Inetutils) which requires facility to be explicitly specified. 

The one comes in `util-linux` works with or without facility so it will keep working as it was.