### PR TITLE
Add plugin support for wilco-ec battery care

### DIFF
--- a/bat.d/66-wilco-ec
+++ b/bat.d/66-wilco-ec
@@ -108,25 +108,24 @@ batdrv_init () {
     if [ -z "$_batteries" ]; then
         echo_debug "bat" "batdrv_init.${_batdrv_plugin}.no_batteries"
         return 2
-    else
-        if [ "$NATACPI_ENABLE" = "0" ]; then
-            # natacpi disabled in configuration --> skip actual detection
-            _natacpi=32
-        else
-            sysf="$ACPIBATDIR/wilco-charger"
+    fi
 
-            if readable_sysf "$sysf/charge_control_start_threshold" \
-                && readable_sysf "$sysf/charge_control_end_threshold"; then
-                # threshold sysfiles exist and are actually readable
-                _bf_start="$sysf/charge_control_start_threshold"
-                _bf_stop="$sysf/charge_control_end_threshold"
-                _bf_chtype="$sysf/charge_type"
-                _bm_thresh="natacpi"
-                _natacpi=0
-            else
-                # laptop model not supported by the driver
-                _natacpi=254
-            fi
+    if [ "$NATACPI_ENABLE" = "0" ]; then
+        # natacpi disabled in configuration --> skip actual detection
+        _natacpi=32
+    else
+        sysf="$ACPIBATDIR/wilco-charger"
+        if readable_sysf "$sysf/charge_control_start_threshold" \
+            && readable_sysf "$sysf/charge_control_end_threshold"; then
+            # threshold sysfiles exist and are actually readable
+            _bf_start="$sysf/charge_control_start_threshold"
+            _bf_stop="$sysf/charge_control_end_threshold"
+            _bf_chtype="$sysf/charge_type"
+            _bm_thresh="natacpi"
+            _natacpi=0
+        else
+            # laptop model not supported by the driver
+            _natacpi=254
         fi
     fi
 
@@ -597,7 +596,7 @@ batdrv_show_battery_data () {
     if [ "$_bm_thresh" = "natacpi" ]; then
         printf "%-59s = %s [%%]\n" "$_bf_start" "$(batdrv_read_threshold start 1)"
         printf "%-59s = %s [%%]\n" "$_bf_stop"  "$(batdrv_read_threshold stop 1)"
-        printparm "%-59s = ##%s##" "$ACPIBATDIR/wilco-charger/charge_type" "not available"
+        printparm "%-59s = ##%s##" "$_bf_chtype" "not available"
         printf "\n"
     fi
 


### PR DESCRIPTION
Modified `65-dell` to add plugin support for `wilco-ec` battery care on a Dell laptop that is using Wilco EC.

This is for the feature requested at https://github.com/linrunner/TLP/issues/838. Sample output follows.

```
# tlp-stat -b -v
--- TLP 1.9.0 --------------------------------------------

+++ Battery Care
Plugin: wilco-ec
Supported features: charge thresholds
Driver usage:
* natacpi (wilco_charger) = active (charge thresholds)
Parameter value ranges:
* START_CHARGE_THRESH_BAT0/1:  50..95(default)
* STOP_CHARGE_THRESH_BAT0/1:   55..100(default)

/sys/class/power_supply/wilco-charger/charge_control_start_threshold = 55 [%]
/sys/class/power_supply/wilco-charger/charge_control_end_threshold = 60 [%]
/sys/class/power_supply/wilco-charger/charge_type           = Custom

+++ Battery Status: BAT0
/sys/class/power_supply/BAT0/manufacturer                   = SMP-ATL3.61
/sys/class/power_supply/BAT0/model_name                     = DELL 7VTMN8C
/sys/class/power_supply/BAT0/cycle_count                    =     15
/sys/class/power_supply/BAT0/charge_full_design             =   4500 [mAh]
/sys/class/power_supply/BAT0/charge_full                    =   4500 [mAh]
/sys/class/power_supply/BAT0/charge_now                     =   2678 [mAh]
/sys/class/power_supply/BAT0/current_now                    =      1 [mA]
/sys/class/power_supply/BAT0/status                         = Not charging

/sys/class/power_supply/BAT0/voltage_min_design             =  11400 [mV]
/sys/class/power_supply/BAT0/voltage_now                    =  11612 [mV]

Charge                                                      =   59.5 [%]
Capacity                                                    =  100.0 [%]
```