### PR TITLE
Implement charge_types sysf usage for lenovo

### DIFF
--- a/bat.d/15-lenovo
+++ b/bat.d/15-lenovo
@@ -481,7 +481,7 @@ batdrv_show_battery_data () {
         if [ "$_bm_thresh" = "natacpi" ] && [ "$_natacpi" = "0" ]; then
             local th sfx=
             printf "\nParameter value range:\n"
-            printf "* STOP_CHARGE_THRESH_$bat: 0(off), 1(on) -- battery long life mode\n\n"
+            printf "* STOP_CHARGE_THRESH_%s: 0(off), 1(on) -- battery long life mode\n\n" "$bat"
             if th=$(batdrv_read_threshold stop 1); then
                 case $th in
                     0) sfx=" (off)" ;;


### PR DESCRIPTION
Uses the new charge_types instead of the conservation_mode setting on kernel version 6.17 onwards. This resolves issue #831. Should still be backwards compatible, and uses the suggestion of setting _natacpi to 1 if using the older system. 

Since this setting is now per battery, I have also changed how tlp-stat -b outputs to have this info per battery. However, I haven't reformatted it so this might need more work. Also, it still shows the value as being 0 or 1 in tlp-stat despite the underlying info being different, and I'm not sure that's most transparent for the user.

```
+++ Battery Status: BAT0
/sys/class/power_supply/BAT0/manufacturer                   = COSMX
/sys/class/power_supply/BAT0/model_name                     = L24X4PC0
/sys/class/power_supply/BAT0/cycle_count                    =      6
/sys/class/power_supply/BAT0/energy_full_design             =  80000 [mWh]
/sys/class/power_supply/BAT0/energy_full                    =  83890 [mWh]
/sys/class/power_supply/BAT0/energy_now                     =  67120 [mWh]
/sys/class/power_supply/BAT0/power_now                      =      0 [mW]
/sys/class/power_supply/BAT0/status                         = Not charging

Parameter value range:
* STOP_CHARGE_THRESH_BAT0: 0(off), 1(on) -- battery long life mode

/sys/class/power_supply/BAT0/charge_types                   = 1 (on)

Charge                                                      =   80.0 [%]
Capacity                                                    =  104.9 [%]
```
