### PR TITLE
fix: skip vm.laptop_mode on kernels that removed the sysctl

### DIFF
--- a/func.d/15-tlp-func-disk
+++ b/func.d/15-tlp-func-disk
@@ -637,6 +637,7 @@ set_laptopmode () {
         return 0
     fi
 
+    [ -f /proc/sys/vm/laptop_mode ] || return 0
     write_sysf "$isec" /proc/sys/vm/laptop_mode
     echo_debug "disk" "set_laptopmode($1): $isec; rc=$?"
 


### PR DESCRIPTION
/proc/sys/vm/laptop_mode was removed in newer kernels 7.1+.

Check for its existence before writing to avoid the deprecation warning.