### PR TITLE
manpages: fix typo "tplctl" → "tlpctl"

### DIFF
--- a/man/tlp.8
+++ b/man/tlp.8
@@ -111,7 +111,7 @@ whatsoever.
 .SH AUTHORIZATION
 .PP
 Almost all \fBtlp\fR commands require root privileges. To change the TLP profile
-without root, you may use \fBtplctl\fR.
+without root, you may use \fBtlpctl\fR.
 .
 .SH BATTERY CARE
 .PP


### PR DESCRIPTION
Noticed a small typo in tlp.8 while looking at changing the TLP profile as a non-privileged user.