### PR TITLE
get_ethifaces: also detect SoC/platform built-in ethernet devices

### DIFF
--- a/func.d/05-tlp-func-pm
+++ b/func.d/05-tlp-func-pm
@@ -209,16 +209,24 @@ set_sound_power_mode () { # set sound chip power modes
 # --- LAN Devices
 
 get_ethifaces () { # get all eth devices -- retval: $_ethifaces
-    local ei eic
+    local ei eid subsys
     _ethifaces=""
 
-    for eic in "$NETD"/*/device/class; do
-        if [ "$(read_sysf "$eic")" = "0x020000" ] \
-            && [ ! -d "${eic%/class}/ieee80211" ]; then
+    for eid in "$NETD"/*/device; do
+        # only ethernet devices (ARPHRD_ETHER = 1) on real hardware buses
+        [ "$(read_sysf "${eid%/device}/type")" = "1" ] || continue
+        subsys=$(readlink -f "$eid/subsystem" 2>/dev/null)
+        case "${subsys##*/}" in
+            pci|platform|usb) ;;
+            *) continue ;;
+        esac
 
-            ei="${eic%/device/class}"; ei="${ei##*/}"
-            _ethifaces="${_ethifaces}${_ethifaces:+ }${ei}"
-        fi
+        # skip wireless interfaces
+        [ -d "$eid/ieee80211" ] && continue
+        [ -d "${eid%/device}/wireless" ] && continue
+
+        ei="${eid%/device}"; ei="${ei##*/}"
+        _ethifaces="${_ethifaces}${_ethifaces:+ }${ei}"
     done
 
     return 0


### PR DESCRIPTION
The previous implementation only matched interfaces whose device has a PCI class attribute of 0x020000 (Ethernet controller). NICs on non-PCI buses, e.g. ethernet built into SoCs (platform devices such as Phytium PHYT0056), have no "device/class" file at all, so they were never added to _ethifaces and WOL (disable_wake_on_lan) silently did nothing for them.

Keep the original PCI class check untouched and add a second branch that accepts platform devices whose netdev type is ARPHRD_ETHER (=1) and whose device subsystem is "platform". USB NICs (no PCI class, USB subsystem) as well as wireless interfaces (ieee80211/wireless) and virtual ones (veth, bridge, docker0, bond, ... have no "device" link) stay excluded. Behavior for existing PCI-based systems is unchanged.

Verified on:
- x86_64 with enp3s0/enp4s0 (PCI): both detected, lo/virbr0/vnet excluded
- aarch64 SoC board with enaphyt56i0 (platform PHYT0056): detected, USB ethernet (cdc_ncm) and USB WiFi wlx* excluded